### PR TITLE
Fix libwtk_sdl2_test-gui link error

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,6 +51,6 @@ libwtk_sdl2_la_LIBADD = $(sdl2_LIBS) $(SDL2_ttf_LIBS) $(SDL2_image_LIBS)
 
 bin_PROGRAMS = libwtk-sdl2-test
 libwtk_sdl2_test_SOURCES = gui.cpp
-libwtk_sdl2_test_LDADD = libwtk-sdl2.la $(SDL2_image_LIBS)
+libwtk_sdl2_test_LDADD = libwtk-sdl2.la $(SDL2_ttf_LIBS) $(SDL2_image_LIBS)
 libwtk_sdl2_test_CXXFLAGS = $(flags)
 


### PR DESCRIPTION
```
/usr/bin/ld: libwtk_sdl2_test-gui.o: undefined reference to symbol 'TTF_Init'
/usr/bin/ld: //usr/lib/arm-linux-gnueabihf/libSDL2_ttf-2.0.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:573: libwtk-sdl2-test] Error 1
```